### PR TITLE
Fix "Cannot find path..." error on first run

### DIFF
--- a/z.psm1
+++ b/z.psm1
@@ -503,8 +503,7 @@ function Save-CdCommandHistory($removeCurrentDirectory = $false) {
 
 function WriteHistoryToDisk() {
   $newList = GetAllHistoryAsText $global:history
-  Out-File -InputObject $newList -FilePath "$cdHistory.tmp"
-  Move-Item -Path "$cdHistory.tmp" -Destination $cdHistory -Force
+  Out-File -InputObject $newList -FilePath $cdHistory
 }
 
 function GetAllHistoryAsText($history) {

--- a/z.psm1
+++ b/z.psm1
@@ -504,8 +504,7 @@ function Save-CdCommandHistory($removeCurrentDirectory = $false) {
 function WriteHistoryToDisk() {
   $newList = GetAllHistoryAsText $global:history
   Out-File -InputObject $newList -FilePath "$cdHistory.tmp"
-  if (Test-Path $cdHistory) { Remove-Item $cdHistory }
-  Rename-Item -Path "$cdHistory.tmp" -NewName $cdHistory
+  Move-Item -Path "$cdHistory.tmp" -Destination $cdHistory -Force
 }
 
 function GetAllHistoryAsText($history) {

--- a/z.psm1
+++ b/z.psm1
@@ -504,7 +504,7 @@ function Save-CdCommandHistory($removeCurrentDirectory = $false) {
 function WriteHistoryToDisk() {
   $newList = GetAllHistoryAsText $global:history
   Out-File -InputObject $newList -FilePath "$cdHistory.tmp"
-  Remove-Item $cdHistory
+  if (Test-Path $cdHistory) { Remove-Item $cdHistory }
   Rename-Item -Path "$cdHistory.tmp" -NewName $cdHistory
 }
 


### PR DESCRIPTION
```
Remove-Item : Cannot find path 'C:\Users\Daniel\.cdHistory' because it does not exist.
At C:\Program Files (x86)\WindowsPowerShell\Modules\z\1.1.3\z.psm1:458 char:3
+   Remove-Item $cdHistory
+   ~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\Daniel\.cdHistory:String) [Remove-Item], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand
```

The above error appears when first changing directory after the module is installed (i.e. when `.cdHistory` doest not yet exist.) Although a .cdHistory file is created and subsequent directory changes work fine, the error does seem a bit scary, especially for first time users. Also, `WriteHistoryToDisk()` is slightly simplified by removing the temporary file, as it seems unnecessary.