### PR TITLE
Proposed fix for error on first startup

### DIFF
--- a/z.psm1
+++ b/z.psm1
@@ -616,7 +616,9 @@ function Get-ArgsFilter {
 
 # Get cdHistory and hydrate a in-memory collection
 $global:history = @()
-$global:history += Get-Content -Path $cdHistory -Encoding UTF8 | ? { (-not [String]::IsNullOrWhiteSpace($_)) } | ConvertTo-DirectoryEntry
+if ((Test-Path $cdHistory)) {
+	$global:history += Get-Content -Path $cdHistory -Encoding UTF8 | ? { (-not [String]::IsNullOrWhiteSpace($_)) } | ConvertTo-DirectoryEntry
+}
 
 $orig_cd = (Get-Alias -Name 'cd').Definition
 $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {


### PR DESCRIPTION
I added z to [oh-my-posh](https://github.com/JanJoris/oh-my-posh) because it's awesome. We [noticed](https://github.com/JanJoris/oh-my-posh/issues/7) that on install using PsGet, z throws an error because it tries to read the history which does not exist yet (z does work afterwards though). This should fix that, resulting in showing a nice output and clean install. 