### PR TITLE
Remove invalid HelpInfoURI entry from definition file.

### DIFF
--- a/z.psd1
+++ b/z.psd1
@@ -36,8 +36,6 @@ FunctionsToExport = @('z', 'cdX', 'popdX', 'pushdX')
 # Aliases to export from this module
 AliasesToExport = '*'
 
-HelpInfoURI = 'https://github.com/vincpa/z'
-
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
 


### PR DESCRIPTION
When running `Update-Help` in PowerShell, the command fails with the following text: 

> update-help : Failed to update Help for the module(s) 'z' with UI culture(s) {en-GB} : The value of the HelpInfoUri key in the module manifest must resolve to a container or root URL on a website where the help files are stored. The HelpInfoUri 'https://github.com/vincpa/z' does not resolve to a container.

Removing the HelpInfoURI entry from the Module Definition file will prevent this module from blocking `Update-Help`, or forcing users to use a workaround for updating their modules' help files.

This page gives a breakdown of the difference between HelpInfoURI and HelpURI: https://blogs.technet.microsoft.com/heyscriptingguy/2013/09/19/helpinfouri-helpuri-and-other-help-mysteries/