### PR TITLE
Allow z to work on Linux

### DIFF
--- a/reload-module.ps1
+++ b/reload-module.ps1
@@ -1,0 +1,2 @@
+Remove-Module -Name z -ErrorAction SilentlyContinue
+Import-Module ./z.psm1

--- a/z.psm1
+++ b/z.psm1
@@ -665,6 +665,4 @@ if (-not $global:options) { $global:options = @{CustomArgumentCompleters = @{ };
 
 $global:options['CustomArgumentCompleters']['z:JumpPath'] = $Completion_RunningService
 
-if ($IsWindows) {
-    $function:tabexpansion2 = $function:tabexpansion2 -replace 'End\r\n{', 'End { if ($null -ne $options) { $options += $global:options} else {$options = $global:options}'
-}
+$function:tabexpansion2 = $function:tabexpansion2 -replace 'End(\r\n|\n){', 'End { if ($null -ne $options) { $options += $global:options} else {$options = $global:options}'

--- a/z.psm1
+++ b/z.psm1
@@ -1,4 +1,4 @@
-﻿$cdHistory = Join-Path -Path $Env:USERPROFILE -ChildPath '\.cdHistory'
+﻿$cdHistory = Join-Path -Path $Env:HOME -ChildPath '\.cdHistory'
 
 <#
 
@@ -333,13 +333,16 @@ function Get-DirectoryEntryMatchPredicate {
             $providerMatches = [System.Text.RegularExpressions.Regex]::Match($Path.FullName, $ProviderRegex).Success
         }
 
-        if ($providerMatches) {
+        if ($IsWindows -and $providerMatches) {
             
             # Allows matching of entire names. Remove the first two characters, added by PowerShell when the user presses the TAB key.
             if ($JumpPath.StartsWith('.\')) {
                 $JumpPath = $JumpPath.Substring(2).TrimEnd('\')
             }
 
+            [System.Text.RegularExpressions.Regex]::Match($Path.Name, [System.Text.RegularExpressions.Regex]::Escape($JumpPath), [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Success
+        }
+        else {
             [System.Text.RegularExpressions.Regex]::Match($Path.Name, [System.Text.RegularExpressions.Regex]::Escape($JumpPath), [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Success
         }
     }
@@ -662,4 +665,6 @@ if (-not $global:options) { $global:options = @{CustomArgumentCompleters = @{ };
 
 $global:options['CustomArgumentCompleters']['z:JumpPath'] = $Completion_RunningService
 
-$function:tabexpansion2 = $function:tabexpansion2 -replace 'End\r\n{', 'End { if ($null -ne $options) { $options += $global:options} else {$options = $global:options}'
+if ($IsWindows) {
+    $function:tabexpansion2 = $function:tabexpansion2 -replace 'End\r\n{', 'End { if ($null -ne $options) { $options += $global:options} else {$options = $global:options}'
+}


### PR DESCRIPTION
This PR changes three things about how the current code works to make it work on Linux (#44)

1. Use `$Env.HOME` over `$Env.USERPROFILE`

I understand this works on all platforms, this is the only change which Windows users will see from this PR.

2. Disable the `$providerMatches` regex check which was preventing the run on Linux 

This was the second cross-platform bug in the current code. 

The regex I suspect is doing something Windows-specific. It looks like this: `'(?i)^((Alias|Env|/|Function|Variable):\\)|(\\{1,2}).*?'`. That seems to fail for all paths stored in `$global:history` on Linux. I've put the code behind a `$IsWindows` to keep that behaviour there, as I couldn't think of the real use cases where the regex is useful.

3. Allow `$function:tabexpansion2` to work on non-Windows platforms

We were using a `-Replace` to extend the existing `$function:tabexpansion2` which uses Windows-style newlines of `\r\n` which wasn't matching on Linux and clearing out the whole of the `$function:tabexpansion2` variable. I've changed the `-Replace` matcher to work for `\n` which is the default newline on Linux and Mac.

Minor things:

* VSCode formats Powershell files on save and has disagreements with the current style. I'm happy to resubmit without these formatting changes - but I figured since VSCode is a default text editor these days that you might want to make it easier for others to contribute?
* I wasn't sure how to quickly make changes to the module and reimport it to test things. So I made a helper file called `reload-module.ps1` which does that. I'm happy to drop this as well if there is a more idiomatic way to do this. This is my first time playing with PowerShell plugins so I found it useful.