### PR TITLE
feat(cross-platform): port home directory and tabbing to linux/mac friendly options

### DIFF
--- a/z.psm1
+++ b/z.psm1
@@ -1,4 +1,4 @@
-﻿$cdHistory = Join-Path -Path $Env:USERPROFILE -ChildPath '\.cdHistory'
+﻿$cdHistory = Join-Path -Path $Env:HOME -ChildPath '\.cdHistory'
 
 <#
 
@@ -333,13 +333,15 @@ function Get-DirectoryEntryMatchPredicate {
             $providerMatches = [System.Text.RegularExpressions.Regex]::Match($Path.FullName, $ProviderRegex).Success
         }
 
-        if ($providerMatches) {
+        if ($IsWindows -And $providerMatches) {
             
             # Allows matching of entire names. Remove the first two characters, added by PowerShell when the user presses the TAB key.
             if ($JumpPath.StartsWith('.\')) {
                 $JumpPath = $JumpPath.Substring(2).TrimEnd('\')
             }
 
+            [System.Text.RegularExpressions.Regex]::Match($Path.Name, [System.Text.RegularExpressions.Regex]::Escape($JumpPath), [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Success
+        } else {
             [System.Text.RegularExpressions.Regex]::Match($Path.Name, [System.Text.RegularExpressions.Regex]::Escape($JumpPath), [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Success
         }
     }
@@ -650,4 +652,4 @@ if (-not $global:options) { $global:options = @{CustomArgumentCompleters = @{};N
 
 $global:options['CustomArgumentCompleters']['z:JumpPath'] = $Completion_RunningService
 
-$function:tabexpansion2 = $function:tabexpansion2 -replace 'End\r\n{','End { if ($null -ne $options) { $options += $global:options} else {$options = $global:options}'
+$function:tabexpansion2 = $function:tabexpansion2 -replace 'End(\r\n|\n){','End { if ($null -ne $options) { $options += $global:options} else {$options = $global:options}'

--- a/z.psm1
+++ b/z.psm1
@@ -333,7 +333,7 @@ function Get-DirectoryEntryMatchPredicate {
             $providerMatches = [System.Text.RegularExpressions.Regex]::Match($Path.FullName, $ProviderRegex).Success
         }
 
-        if ($IsWindows -And $providerMatches) {
+        if ($providerMatches) {
             
             # Allows matching of entire names. Remove the first two characters, added by PowerShell when the user presses the TAB key.
             if ($JumpPath.StartsWith('.\')) {
@@ -341,15 +341,16 @@ function Get-DirectoryEntryMatchPredicate {
             }
 
             [System.Text.RegularExpressions.Regex]::Match($Path.Name, [System.Text.RegularExpressions.Regex]::Escape($JumpPath), [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Success
-        } else {
-            [System.Text.RegularExpressions.Regex]::Match($Path.Name, [System.Text.RegularExpressions.Regex]::Escape($JumpPath), [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Success
         }
     }
 }
 
 function Get-CurrentSessionProviderDrives([System.Collections.ArrayList] $ProviderDrives) {
 
-    if ($ProviderDrives -ne $null -and $ProviderDrives.Length -gt 0) {
+    if($IsLinux -Or $IsMacOS) {
+        # Always only '/' which needs escaped to work in a regex
+        '\/'
+    } elseif ($ProviderDrives -ne $null -and $ProviderDrives.Length -gt 0) {
         Get-ProviderDrivesRegex $ProviderDrives
     } else {
 


### PR DESCRIPTION
This addresses #44 and allows `z` to be used on Linux and Macs as well as Windows.

The three cross-platform bugs were:

* `$Env.USERPROFILE` isn't cross-platform, `$Env.HOME` is
* The `Get-DirectoryEntryMatchPredicate` function looks for multiple drive names, on Linux/Mac this is only `/` which needs escaping to be used correctly as a regular expression
* `$function:tabexpansion2` was expecting an extra carriage return in the existing function which doesn't exist on Mac/Linux and was blanking the whole of `$function:tabexpansion2`

Thanks again for writing this plugin, it's great to have `z`!
Joe.