### PR TITLE
Fix ListFiles and OnlyCurrentDirectory

### DIFF
--- a/z.psm1
+++ b/z.psm1
@@ -89,13 +89,13 @@ function z {
 )
 
     if (((-not $Clean) -and (-not $Remove) -and (-not $ListFiles)) -and [string]::IsNullOrWhiteSpace($JumpPath)) { Get-Help z; return; }
- 
+
     # If a valid path is passed in to z, treat it like the normal cd command
-    if (-not [string]::IsNullOrWhiteSpace($JumpPath) -and (Test-Path $JumpPath)) {
+    if (-not $ListFiles -and -not [string]::IsNullOrWhiteSpace($JumpPath) -and (Test-Path $JumpPath)) {
         cdX $JumpPath
         return;
     }
-    
+
     if ((Test-Path $cdHistory)) {
         if ($Remove) {
         Save-CdCommandHistory $Remove

--- a/z.psm1
+++ b/z.psm1
@@ -109,7 +109,11 @@ function z {
             $providerRegex = $null
 
             If ($OnlyCurrentDirectory) {
-                $providerRegex = (Get-FormattedLocation).replace('\','\\') + '\\.*?'
+                $providerRegex = (Get-FormattedLocation).replace('\','\\')
+                if (-not $providerRegex.EndsWith('\\')) {
+                    $providerRegex += '\\'
+                }
+                $providerRegex += '.*?'
             } else {
                 $providerRegex = Get-CurrentSessionProviderDrives ((Get-PSProvider).Drives | select -ExpandProperty Name)
             }


### PR DESCRIPTION
ListFiles was changing directory. I set it not to do so.

OnlyCurrentDirectory regex for drive root looked like `C:\\\\.*?`. I added a check not to duplicate trailing `\`.