### PR TITLE
Add support for .cdHistory file being hidden

### DIFF
--- a/z.psm1
+++ b/z.psm1
@@ -507,7 +507,7 @@ function Save-CdCommandHistory($removeCurrentDirectory = $false) {
 
 function WriteHistoryToDisk() {
   $newList = GetAllHistoryAsText $global:history
-  Set-Content -Value $newList -Path $cdHistory
+  Set-Content -Value $newList -Path $cdHistory -Encoding UTF8
 }
 
 function GetAllHistoryAsText($history) {

--- a/z.psm1
+++ b/z.psm1
@@ -507,7 +507,7 @@ function Save-CdCommandHistory($removeCurrentDirectory = $false) {
 
 function WriteHistoryToDisk() {
   $newList = GetAllHistoryAsText $global:history
-  Out-File -InputObject $newList -FilePath $cdHistory
+  Set-Content -Value $newList -Path $cdHistory
 }
 
 function GetAllHistoryAsText($history) {


### PR DESCRIPTION
Update WriteHistoryToDisk function to use Set-Content instead of Out-File since Out-File throws an access denied exception when trying to write to a hidden file.

A common practice on Windows is to make the dotfiles in the user home folder hidden, and doing that on .cdHistory currently causes an exception whenever .cdHistory is updated.